### PR TITLE
CTV-1747: update DOCS to account for removal of `truex_global_config.json`

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -149,7 +149,8 @@ The true[X] interactive ad component and its rendering logic are distributed as 
        adParameters : "<Ad parameters associative array as returned by SSAI>",
        slotType : "<the type of the current ad pod>",
        supportsUserCancelStream : <optional; set to true to enable the userCancelStream event>,
-       logLevel : <optional; set the verbosity of true[X] logging, from 0 (mute) to 5 (verbose)>
+       logLevel : <optional; set the verbosity of true[X] logging, from 0 (mute) to 5 (verbose), defaults to 5>,
+       channelWidth : <optional; set the width in pixels of the channel's interface, defaults to 1920>
    }
 ```
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -2,7 +2,7 @@
 
 # TruexAdRenderer Roku Documentation
 
-Version 1.0.0
+Version 1.1.0
 
 ## Contents
 
@@ -148,7 +148,8 @@ The true[X] interactive ad component and its rendering logic are distributed as 
        type : "init",
        adParameters : "<Ad parameters associative array as returned by SSAI>",
        slotType : "<the type of the current ad pod>",
-       supportsUserCancelStream : <optional; set to true to enable the userCancelStream event>
+       supportsUserCancelStream : <optional; set to true to enable the userCancelStream event>,
+       logLevel : <optional; set the verbosity of true[X] logging, from 0 (mute) to 5 (verbose)>
    }
 ```
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -150,7 +150,8 @@ The true[X] interactive ad component and its rendering logic are distributed as 
        slotType : "<the type of the current ad pod>",
        supportsUserCancelStream : <optional; set to true to enable the userCancelStream event>,
        logLevel : <optional; set the verbosity of true[X] logging, from 0 (mute) to 5 (verbose), defaults to 5>,
-       channelWidth : <optional; set the width in pixels of the channel's interface, defaults to 1920>
+       channelWidth : <optional; set the width in pixels of the channel's interface, defaults to 1920>,
+       channelHeight : <optional; set the height in pixels of the channel's interface, defaults to 1080>
    }
 ```
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -164,7 +164,9 @@ The parameters for this method call are:
 * `adParameters`: AdParameters as returned by SSAI. In the example of Uplynk, this would correspond to `response.ads.breaks[0].ads[0].adParameters`
 * `slotType`: the type of the current ad pod, `PREROLL` or `MIDROLL`
 * `supportsUserCancelStream`: optional -- set to `true` to enable the [userCancelStream](#usercancelstream) event
-
+* `logLevel` : optional; set the verbosity of true[X] logging, from 0 (mute) to 5 (verbose), defaults to 5
+* `channelWidth` : optional; set the width in pixels of the channel's interface, defaults to 1920
+* `channelHeight` : optional; set the height in pixels of the channel's interface, defaults to 1080
 
 #### `start`
 


### PR DESCRIPTION
This PR captures the DOCS update to account for the following parameters which were moved from the `truex_global_config.json` file to optional `init` fields:

- `logLevel`
- `channelWidth`
- `channelHeight`